### PR TITLE
feat: 移除pipe的时候，同步修改源码模式下的数据

### DIFF
--- a/packages/core/src/components/codeRun/inputPanel/index.tsx
+++ b/packages/core/src/components/codeRun/inputPanel/index.tsx
@@ -19,10 +19,11 @@ const inputItems = [
 interface IVisualFormItemProps {
   type: string;
   desc: string;
+  markAdded: () => any;
 }
 
 const VisualFormItem: React.FC<IVisualFormItemProps> = (props) => {
-  const { type, desc } = props;
+  const { type, desc, markAdded } = props;
 
   return (
     <React.Fragment>
@@ -59,7 +60,7 @@ const VisualFormItem: React.FC<IVisualFormItemProps> = (props) => {
                 block={true}
                 type={'dashed'}
                 icon={<PlusOutlined />}
-                onClick={() => add()}
+                onClick={() => add(markAdded())}
               >
                 新增
               </Button>
@@ -80,6 +81,10 @@ const VisualPanel: React.FC<IVisualPanelProps> = (props) => {
   const { data, onChange } = props;
   const [form] = Form.useForm();
 
+  // a flag, when add a form-item marked it true.
+  const addRef = useRef(false);
+  const markAdded = () => addRef.current = true;
+
   useEffect(() => {
     const filedsValue: { [key: string]: any } = {};
     for (const { type } of inputItems) {
@@ -90,13 +95,19 @@ const VisualPanel: React.FC<IVisualPanelProps> = (props) => {
   }, [data]);
 
   const onFormChange = () => {
+
+    // if mark add, ignore it
+    if (addRef.current) return (addRef.current = false);
+
     const input: { [key: string]: any } = {};
     const filedsValue = form.getFieldsValue();
     for (const { type } of inputItems) {
       const mockValue = filedsValue[type] || [];
       input[type] = mockValue.reduce((prev: any, cur: { key: string, value: any }) => {
-        const { key, value } = cur;
-        prev[key] = value;
+        if (cur) {
+          const { key, value } = cur;
+          prev[key] = value;
+        }
         return prev;
       }, {});
     }
@@ -108,13 +119,14 @@ const VisualPanel: React.FC<IVisualPanelProps> = (props) => {
       <Form
         form={form}
         autoComplete={'on'}
-        onChange={onFormChange}
+        onValuesChange={onFormChange}
       >
         {inputItems.map(({ type, desc }, index) => (
           <VisualFormItem
             key={index}
             type={type}
             desc={desc}
+            markAdded={markAdded}
           />
         ))}
       </Form>


### PR DESCRIPTION
[![soF5wt.png](https://s3.ax1x.com/2021/01/22/soF5wt.png)](https://imgchr.com/i/soF5wt)

操作步骤：
1、可视化模式下，增加 `pipe` 中的 `key-value`
2、运行
3、删除 `pipe` 中的任意一条，发现源码模式的数据没有同步，导致运行出来的结果也不对（依然有删除的那一条）
原因：
`<MinusCircleOutlined onClick={() => remove(field.name)} />` 这里执行移除的时候并没有触发 `form` 的 `onChange` 事件，
看了一下 `antd` 文档，建议使用 `onValuesChange`，测试了一下移除的时候可以触发了，只是掉入了另一个坑，就是 `add` 的时候同样触发了，所以加了一个锁解决。