### PR TITLE
fix(compile-code): run imove-branch node port condition only once

### DIFF
--- a/example/src/pages/index.tsx
+++ b/example/src/pages/index.tsx
@@ -7,8 +7,8 @@ const onSave = (data: { nodes: any; edges: any }): void => {
 
 function Arrange(): JSX.Element {
   return (
-    <div style={{height: '100vh'}}>
-      <IMove onSave={onSave}/>
+    <div style={{ height: '100vh' }}>
+      <IMove onSave={onSave} />
     </div>
   );
 }


### PR DESCRIPTION
In [packages/compile-code/src/template/logic.ts#_getNextNodes()](https://github.com/ykfe/imove/blob/d7c128ad43434118b289d2896dbdb09e5a6a6a91/packages/compile-code/src/template/logic.ts#L64), `imove-branch` node conditions will be tested as much times as `this.edges.length` cuz [the checking code](https://github.com/ykfe/imove/blob/d7c128ad43434118b289d2896dbdb09e5a6a6a91/packages/compile-code/src/template/logic.ts#L69) were placed in the `for (const edge of this.edges)` loop. We can move them out the loop so it will run only once.