### PR TITLE
feature: update analyze dependences regex

### DIFF
--- a/packages/compile-code/src/compileForOnline.ts
+++ b/packages/compile-code/src/compileForOnline.ts
@@ -23,7 +23,7 @@ interface DSL {
 
 const INSERT_DSL_COMMENT = '// define dsl here';
 const INSERT_NODE_FNS_COMMENT = '// define nodeFns here';
-const importRegex = /import\s+([\s\S]*?)\s+from\s+(?:('[@\.\/\-\w]+')|("[@\.\/\-\w]+"))\s*;?/gm;
+const importRegex = /import\s([\s\S]*?)\sfrom\s('|")((@\w[\w\.\-]+\/)?(\w[\w\.\-\/]+))\2/gm;
 const virtualSourceNode = {
   id: 'virtual-imove-start',
   shape: 'imove-start',
@@ -92,8 +92,7 @@ const compileNodeFn = (node: Cell.Properties): string => {
     .replace(
       importRegex,
       (match: string, p1: string, p2: string, p3: string) => {
-        const pkgName = (p2 || p3).replace(/('|")/g, '');
-        return `const ${p1} = (await import('https://jspm.dev/${pkgName}')).default;`;
+        return `const ${p1} = (await import('https://jspm.dev/${p3}')).default;`;
       },
     )
     .replace(/export\s+default/, 'return');

--- a/packages/core/src/utils/analyzeDeps.ts
+++ b/packages/core/src/utils/analyzeDeps.ts
@@ -2,20 +2,15 @@ import axios from 'axios';
 import { safeGet } from './index';
 import { getLocalConfig } from '../api';
 
-const regex = /import\s([\s\S]*?)\sfrom\s(?:('[@\.\/\-\w]+')|("[@\.\/\-\w]+"))/gm;
+const regex = /import\s([\s\S]*?)\sfrom\s('|")((@\w[\w\.\-]+\/)?(\w[\w\.\-]+))(\/[\w\.\-]+)*\2/gm;
+//                     (1       )        (2  )(3(4            ) (5          ))(6          )
 
 const extractPkgs = (code: string, excludePkgs?: string[]): string[] => {
   let matchRet = null;
   const pkgNames: string[] = [];
   while ((matchRet = regex.exec(code)) != null) {
-    let pkgName = matchRet[2] || matchRet[3];
-    pkgName = pkgName.slice(1, pkgName.length - 1);
-    // NOTE: ignore relative path (./ and ../) and excludePkgs
-    if (
-      pkgName.indexOf('./') === -1 &&
-      pkgName.indexOf('../') === -1 &&
-      excludePkgs?.indexOf(pkgName) === -1
-    ) {
+    const pkgName = matchRet[3];
+    if (excludePkgs?.indexOf(pkgName) === -1) {
       pkgNames.push(pkgName);
     }
   }


### PR DESCRIPTION
1. Support the usage like `import at from "lodash/at"`
2. Fix compile-code with relative import path like `import sth from './sth'`